### PR TITLE
Add required ConsentToTrack to subscribe call

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -116,7 +116,8 @@ class Api extends CampaignMonitor
         $subscriberData = [
             'EmailAddress' => $email,
             'Resubscribe' => true,
-            'RestartSubscriptionBasedAutoresponders' => true
+            'RestartSubscriptionBasedAutoresponders' => true,
+            'ConsentToTrack' => 'Unchanged',
         ];
 
         $listId = $this->helperData->getListId($storeId);


### PR DESCRIPTION
If the customer indicated they allow emails to be tracked this could be 'Yes' but the correct value is 'Unchanged' since Magento does not ask this question. I think it will still allow tracking.